### PR TITLE
Implement notional check before market orders

### DIFF
--- a/bot_trading.py
+++ b/bot_trading.py
@@ -90,6 +90,13 @@ class FuturesBot:
     def abrir_posicion(self, side, amount):
         try:
             position_side = "LONG" if side == "buy" else "SHORT"
+
+            price = self.exchange.fetch_ticker(self.symbol)["last"]
+            notional = amount * price
+            if notional < 100:
+                amount = 100 / price
+                log(f"Futuros: Ajustando cantidad a {amount} para cumplir el notional mínimo")
+
             order = self.exchange.create_market_order(self.symbol, side, amount)
 
             entry_price = float(order['info'].get('avgFillPrice') or order['price'])


### PR DESCRIPTION
## Summary
- update futures trading bot to ensure orders meet the $100 notional requirement

## Testing
- `python -m py_compile bot_trading.py`
- `python bot_trading.py` *(fails: ModuleNotFoundError: No module named 'ccxt')*

------
https://chatgpt.com/codex/tasks/task_e_68581e0c41cc832d88db13beeff1ee51