### PR TITLE
Implement amount rounding logic

### DIFF
--- a/bot_trading.py
+++ b/bot_trading.py
@@ -3,6 +3,7 @@ import time
 import ccxt
 import json
 import logging
+import math
 from dotenv import load_dotenv
 
 import pandas as pd
@@ -93,9 +94,17 @@ class FuturesBot:
 
             price = self.exchange.fetch_ticker(self.symbol)["last"]
             notional = amount * price
+            precision = self.exchange.markets[self.symbol]["precision"]["amount"]
             if notional < 100:
                 amount = 100 / price
-                log(f"Futuros: Ajustando cantidad a {amount} para cumplir el notional mínimo")
+                step = 10 ** -precision
+                amount = math.ceil(amount / step) * step
+                log(
+                    f"Futuros: Ajustando cantidad a {amount} para cumplir el notional mínimo"
+                )
+
+            amount = float(self.exchange.amount_to_precision(self.symbol, amount))
+            log(f"Futuros: Cantidad redondeada a {amount}")
 
             order = self.exchange.create_market_order(self.symbol, side, amount)
 


### PR DESCRIPTION
## Summary
- ensure market order amounts respect symbol precision and 100 USDT minimum notional in `abrir_posicion`
- log the rounded quantity when placing futures orders

## Testing
- `python -m py_compile bot_trading.py patterns.py`
- `python -m pip install -r requirements.txt` *(fails: Could not fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_685822ae8aa0832d9be6dec2b7d5c371