### PR TITLE
Improve closing position summary

### DIFF
--- a/bot_trading.py
+++ b/bot_trading.py
@@ -112,7 +112,13 @@ class FuturesBot:
     
     def cerrar_posicion(self):
         try:
-            os.remove(self.pos_file)
+            pos = cargar_posicion(self.pos_file)
+            if pos and hasattr(self, "_actualizar_summary"):
+                try:
+                    self._actualizar_summary(pos)
+                except Exception as e:
+                    log(f"Futuros: Error actualizando summary: {e}")
+            eliminar_posicion(self.pos_file)
         except Exception as e:
             log(f"Futuros: Error al cerrar posición: {e}")
 


### PR DESCRIPTION
## Summary
- update the futures bot so closing a position loads its data and updates the summary before deleting the file

## Testing
- `python -m py_compile bot_trading.py patterns.py`


------
https://chatgpt.com/codex/tasks/task_e_685822b049e0832db87528e2fb83c269