### PR TITLE
Implement daily log rotation

### DIFF
--- a/bot_trading.py
+++ b/bot_trading.py
@@ -4,6 +4,7 @@ import time
 import ccxt
 import json
 import logging
+import logging.handlers
 import math
 from dotenv import load_dotenv
 from patterns import detect_patterns
@@ -50,13 +51,33 @@ def detectar_breakout(exchange, symbol):
 
 load_dotenv()
 
-# Configuración del logger
+# Configuración del logger con rotación diaria
 os.makedirs("logs", exist_ok=True)
-logging.basicConfig(filename="logs/bot.log", level=logging.INFO, format="%(asctime)s - %(message)s")
+
+logger = logging.getLogger("bot")
+logger.setLevel(logging.INFO)
+
+handler = logging.handlers.TimedRotatingFileHandler(
+    "logs/bot.log",
+    when="midnight",
+    backupCount=7,
+    encoding="utf-8",
+)
+handler.suffix = "%Y-%m-%d"
+handler.namer = lambda name: name.replace(".log.", "_") + ".log"
+
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+handler.setFormatter(formatter)
+
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(formatter)
+
+logger.addHandler(handler)
+logger.addHandler(console_handler)
+
 
 def log(msg):
-    print(msg)
-    logging.info(msg)
+    logger.info(msg)
 
 def cargar_posicion(path):
     if os.path.exists(path):


### PR DESCRIPTION
## Summary
- rotate the log daily at midnight
- keep 7 old log files with the date in the filename
- stream logs to console and file
- remove `print()` calls so everything logs through the logger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673889fea0832d9ba471bf849275c0