### PR TITLE
Use ARM container for Lambda packaging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,22 +13,17 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.11' # o la versión que uses
-
-      - name: Install dependencies into package folder
+      - name: Build deployment package on Amazon Linux
         run: |
-          mkdir package
-          pip install -r requirements.txt -t package
-          cp -r bot_trading.py package/
-
-      - name: Zip package
-        run: |
-          cd package
-          zip -r ../deployment.zip .
-          cd ..
+          docker run --rm --platform linux/arm64 -v "$PWD":/var/task -w /var/task amazonlinux:2 bash -c "
+            yum -y install python3 python3-pip zip &&
+            python3 -m pip install --upgrade pip &&
+            mkdir -p package &&
+            pip3 install -r requirements.txt -t package &&
+            cp bot_trading.py package/ &&
+            cd package &&
+            zip -r ../deployment.zip .
+          "
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## Summary
- build Lambda deployment package using `--platform linux/arm64`

## Testing
- `python3 -m py_compile bot_trading.py patterns.py`


------
https://chatgpt.com/codex/tasks/task_e_687002981dfc832d91711991e01dd988