### PR TITLE
Update docker image for Lambda build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,8 @@ jobs:
 
       - name: Build deployment package on Amazon Linux
         run: |
-          docker run --rm --platform linux/x86_64 -v "$PWD":/var/task -w /var/task amazonlinux:2 bash -c "
-            yum -y install python3 python3-pip zip &&
-            yum groupinstall -y \"Development Tools\" &&
+          docker run --rm --platform linux/x86_64 -v "$PWD":/var/task -w /var/task public.ecr.aws/lambda/python:3.13 bash -c "
+            yum -y install gcc python3-devel libffi-devel openssl-devel zip &&
             python3 -m pip install --upgrade pip &&
             mkdir -p package &&
             pip3 install -r requirements.txt -t package &&


### PR DESCRIPTION
## Summary
- use the Python 3.13 Lambda base image for docker build
- install gcc and development packages needed to compile cryptography deps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687023e5ac2c832d8b274af08e5d2e10