### PR TITLE
Fix pip upgrade step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
           docker run --rm --platform linux/x86_64 -v "$PWD":/var/task -w /var/task amazonlinux:2023 bash -c "
             yum -y groupinstall 'Development Tools' &&
             yum -y install python3 python3-pip zip &&
-            pip3 install --upgrade pip &&
+            pip3 install --upgrade pip --ignore-installed &&
             mkdir -p package &&
             pip3 install -r requirements.txt -t package &&
             cp bot_trading.py package/ &&


### PR DESCRIPTION
## Summary
- add `--ignore-installed` flag when upgrading pip in Docker build step

## Testing
- `python3 -m py_compile bot_trading.py patterns.py`

------
https://chatgpt.com/codex/tasks/task_e_68702a84c7b0832dbe2f29381e9631e1