### PR TITLE
Fix docker run quoting to avoid syntax errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,18 +17,17 @@ jobs:
         run: |
           docker run --rm --platform linux/x86_64 \
             -v "$PWD":/var/task -w /var/task \
-            public.ecr.aws/sam/build-python3.13:latest bash -c "
-              set -e
-              yum -y groupinstall 'Development Tools' &&
+            public.ecr.aws/sam/build-python3.13:latest \
+            bash -c 'set -e &&
+              yum -y groupinstall "Development Tools" &&
               yum -y install python3 python3-pip python3-devel gcc libffi-devel openssl-devel make zip &&
               python3 -m pip install --upgrade pip &&
               mkdir -p package &&
               python3 -m pip install -r requirements.txt -t package &&
-              python3 -c "import importlib.util, sys; spec = importlib.util.find_spec('_cffi_backend'); print('_cffi_backend found at:', spec.origin if spec else 'not found'); sys.exit(1 if not spec else 0)" &&
+              python3 -c '\''import importlib.util, sys; spec = importlib.util.find_spec("_cffi_backend"); print("_cffi_backend found at:", spec.origin if spec else "not found"); sys.exit(1 if not spec else 0)'\'' &&
               cp bot_trading.py package/ &&
               cd package &&
-              zip -r ../deployment.zip .
-            "
+              zip -r ../deployment.zip .'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## Summary
- fix quoting for the docker run step in deploy.yml

## Testing
- `bash -c 'python3 -c '\''import importlib.util, sys; spec = importlib.util.find_spec("_cffi_backend"); print("_cffi_backend found at:", spec.origin if spec else "not found"); sys.exit(1 if not spec else 0)'\''`

------
https://chatgpt.com/codex/tasks/task_e_6870540307d8832db0d4ad4fda91c71f