### PR TITLE
Add multistage Dockerfile for AWS Lambda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM amazonlinux:2023 AS builder
+RUN yum groupinstall -y "Development Tools" && \
+    yum install -y gcc libffi-devel openssl-devel python3 python3-pip make zip
+
+COPY requirements.txt .
+RUN python3 -m pip install --upgrade pip && \
+    pip install -r requirements.txt -t /package
+
+FROM public.ecr.aws/sam/build-python3.13 AS final
+COPY --from=builder /package /var/task
+COPY bot_trading.py /var/task


### PR DESCRIPTION
## Summary
- create Dockerfile with two stages
  - stage based on amazonlinux:2023 to install build tools and Python dependencies
  - stage using AWS Lambda runtime image to assemble the package

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68705ca93108832d980814d589b97586