### PR TITLE
Add default workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ RUN python3 -m pip install --upgrade pip && \
     pip install -r requirements.txt -t /package
 
 FROM public.ecr.aws/sam/build-python3.13 AS final
+WORKDIR /var/task
 COPY --from=builder /package /var/task
 COPY bot_trading.py /var/task


### PR DESCRIPTION
## Summary
- set `/var/task` as the working directory in the final image stage

## Testing
- `python3 -m py_compile bot_trading.py patterns.py`


------
https://chatgpt.com/codex/tasks/task_e_68705e7caaf4832daaf3ab729626a3e5