### PR TITLE
Fix Dockerfile pip install step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ RUN yum groupinstall -y "Development Tools" && \
     yum install -y gcc libffi-devel openssl-devel python3 python3-pip make zip
 
 COPY requirements.txt .
-RUN python3 -m pip install --upgrade pip && \
-    pip install -r requirements.txt -t /package
+RUN pip install -r requirements.txt -t /package
 
 FROM public.ecr.aws/sam/build-python3.13 AS final
 WORKDIR /var/task


### PR DESCRIPTION
## Summary
- remove pip upgrade step from Dockerfile

## Testing
- `python3 -m py_compile bot_trading.py patterns.py`

------
https://chatgpt.com/codex/tasks/task_e_687062fa6284832db1ad11286c7a2d92