### PR TITLE
Simplify logging for Lambda

### DIFF
--- a/bot_trading.py
+++ b/bot_trading.py
@@ -4,7 +4,6 @@ import time
 import ccxt
 import json
 import logging
-import logging.handlers
 import math
 from dotenv import load_dotenv
 from pattern_detection import detect_patterns
@@ -53,29 +52,15 @@ def detectar_breakout(exchange, symbol):
 
 load_dotenv()
 
-# Configuración del logger con rotación diaria
-os.makedirs("logs", exist_ok=True)
-
+# Configuración del logger para AWS Lambda
 logger = logging.getLogger("bot")
 logger.setLevel(logging.INFO)
 
-handler = logging.handlers.TimedRotatingFileHandler(
-    "logs/bot.log",
-    when="midnight",
-    backupCount=7,
-    encoding="utf-8",
-    utc=True,
-)
-handler.suffix = "%Y-%m-%d"
-handler.namer = lambda name: name.replace(".log.", "_") + ".log"
-
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-handler.setFormatter(formatter)
 
 console_handler = logging.StreamHandler()
 console_handler.setFormatter(formatter)
 
-logger.addHandler(handler)
 logger.addHandler(console_handler)
 
 


### PR DESCRIPTION
## Summary
- simplify logger configuration for AWS Lambda
- remove unused logging.handlers import

## Testing
- `python -m py_compile bot_trading.py pattern_detection.py`

------
https://chatgpt.com/codex/tasks/task_e_6872c809f340832d9720aafa6b266052