### PR TITLE
Switch to python-binance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ccxt
 numpy
 python-dotenv
 cffi


### PR DESCRIPTION
## Summary
- replace `ccxt` with `python-binance`
- adjust all trading API calls to use `python-binance`
- drop `ccxt` from requirements
- fix Binance ticker method name

## Testing
- `python3 -m py_compile bot_trading.py pattern_detection.py`


------
https://chatgpt.com/codex/tasks/task_e_687cf5d45d64832db4f20813c5969a9c