### PR TITLE
Fix duplicated logs in AWS Lambda

### DIFF
--- a/bot_trading.py
+++ b/bot_trading.py
@@ -108,19 +108,20 @@ def detectar_breakout(exchange, symbol, window=ANALYSIS_WINDOW):
 
 load_dotenv()
 
-# Configuración del logger para AWS Lambda
+# Configuración de logging (AWS Lambda)
 logger = logging.getLogger("bot")
 logger.setLevel(logging.INFO)
 
-formatter = logging.Formatter("%(levelname)s - %(message)s")
+if not logger.handlers:
+    formatter = logging.Formatter("%(levelname)s - %(message)s")
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
 
-console_handler = logging.StreamHandler()
-console_handler.setFormatter(formatter)
-
-logger.addHandler(console_handler)
+logger.propagate = False
 
 
-def log(msg):
+def log(msg: str):
     logger.info(msg)
 
 


### PR DESCRIPTION
## Summary
- Ensure Lambda logger uses single handler without timestamp
- Disable propagation to avoid duplicated log lines

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4fae5d40c832da9a0f947288a03f5