### PR TITLE
Add SUP_INTERVAL env var to handler

### DIFF
--- a/bot_trading.py
+++ b/bot_trading.py
@@ -943,6 +943,7 @@ def handler(event, context):
     testnet = os.getenv("BINANCE_TESTNET", "false").lower() == "true"
 
     symbol = os.getenv("SYMBOL", "BTC/USDT")
+    SUP_INTERVAL = os.getenv("SUP_INTERVAL", "5m")
     leverage = 5
     use_breakout_dynamic_stops = (
         os.getenv("USE_BREAKOUT_DYNAMIC_STOPS", "false").lower() == "true"


### PR DESCRIPTION
## Summary
- expose SUP_INTERVAL environment variable for AWS Lambda handler

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5de31e608832d94805242384ecb88