### PR TITLE
Allow passing external client for support/resistance calculations

### DIFF
--- a/bot_trading.py
+++ b/bot_trading.py
@@ -808,7 +808,7 @@ def _run_iteration(exchange, bot, testnet, symbol, leverage=None):
         interval = os.getenv("SUP_INTERVAL", "5m")
 
         sup_levels = next_supports(
-            symbol_ref, interval=interval, limit=500, log_fn=log
+            symbol_ref, interval=interval, limit=500, log_fn=log, exchange=exchange
         )
         if sup_levels:
             top_sup = sup_levels[0]
@@ -830,7 +830,9 @@ def _run_iteration(exchange, bot, testnet, symbol, leverage=None):
             else (symbol if "symbol" in locals() else os.getenv("SYMBOL", "DOGE/USDT"))
         )
         interval = os.getenv("RES_INTERVAL", "5m")
-        levels = next_resistances(symbol_ref, interval=interval, limit=500)
+        levels = next_resistances(
+            symbol_ref, interval=interval, limit=500, exchange=exchange
+        )
 
         if levels:
             top = levels[0]

--- a/resistance_levels.py
+++ b/resistance_levels.py
@@ -58,9 +58,14 @@ def _get_client() -> Optional[Client]:
         return None
 
 
-def next_resistances(symbol: str, interval: str = "5m", limit: int = 500) -> List[Dict]:
+def next_resistances(
+    symbol: str,
+    interval: str = "5m",
+    limit: int = 500,
+    exchange: Optional[Client] = None,
+) -> List[Dict]:
     """Estimate next resistance levels above current price."""
-    client = _get_client()
+    client = exchange or _get_client()
     if client is None:
         log("📚 Resistencias estimadas: cliente no disponible")
         return []

--- a/support_levels.py
+++ b/support_levels.py
@@ -47,11 +47,12 @@ def next_supports(
     interval: str = "5m",
     limit: int = 500,
     log_fn: Optional[Callable[[str], None]] = None,
+    exchange: Optional[Client] = None,
 ) -> List[Dict[str, Any]]:
     """Estimate next support levels below current price."""
     log = log_fn or (lambda _msg: None)
 
-    client = _get_client()
+    client = exchange or _get_client()
     if client is None:
         log("🛡️ Soportes estimados: cliente/datos no disponibles")
         return []


### PR DESCRIPTION
## Summary
- add optional `exchange` client parameter to `next_supports` and `next_resistances`
- forward existing client in `_run_iteration` so calculations reuse same exchange connection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a61c82cf6c832d9e75a46f4f21b495