### PR TITLE
Log outgoing Binance requests with masked details

### DIFF
--- a/bot_trading.py
+++ b/bot_trading.py
@@ -15,6 +15,57 @@ from support_levels import next_supports
 from sr_levels import get_sr_levels
 
 
+def _mask_key(key: str) -> str:
+    """Devuelve la clave enmascarada mostrando solo los primeros y últimos 3 caracteres."""
+    if not key:
+        return ""
+    if len(key) <= 6:
+        return key[0] + "***" + key[-1]
+    return f"{key[:3]}***{key[-3:]}"
+
+
+class LoggingSession(requests.Session):
+    """Sesión de requests que registra cada request saliente."""
+
+    def __init__(self, logger):
+        super().__init__()
+        self._logger = logger
+
+    def request(self, method, url, **kwargs):
+        headers = kwargs.get("headers", {})
+        data = kwargs.get("data")
+        ctype = headers.get("Content-Type") or self.headers.get("Content-Type")
+        api_key = headers.get("X-MBX-APIKEY") or self.headers.get("X-MBX-APIKEY")
+
+        body = data or ""
+        if isinstance(body, bytes):
+            body = body.decode()
+
+        has_sig_end = False
+        if body and "signature=" in body:
+            prefix, sig = body.rsplit("signature=", 1)
+            has_sig_end = body.endswith("signature=" + sig)
+            body = f"{prefix}signature=<hidden len={len(sig)}>"
+
+        masked_key = _mask_key(api_key)
+        is_form = ctype == "application/x-www-form-urlencoded"
+
+        self._logger.info(
+            "Request %s %s | Content-Type: %s | X-MBX-APIKEY: %s | body: %s",
+            method.upper(),
+            url,
+            ctype,
+            masked_key,
+            body,
+        )
+        self._logger.info(
+            "Content-Type is application/x-www-form-urlencoded: %s | signature at end: %s",
+            is_form,
+            has_sig_end,
+        )
+        return super().request(method, url, **kwargs)
+
+
 def get_proxies():
     """Devuelve diccionario de proxies o None si no se usa proxy."""
     testnet = os.getenv("BINANCE_TESTNET", "false").lower() == "true"
@@ -1365,6 +1416,13 @@ def handler(event, context):
     proxies = get_proxies()
     req_params = {"proxies": proxies} if proxies else None
     client = Client(key, secret, testnet=testnet, requests_params=req_params)
+
+    session = LoggingSession(logger)
+    session.headers.update(client.session.headers)
+    if proxies:
+        session.proxies.update(proxies)
+    client.session = session
+
     client.timestamp_offset = DRIFT_MS
     client.REQUEST_RECVWINDOW = 5000
     exchange = LoggingClient(client, testnet)


### PR DESCRIPTION
## Summary
- add custom `LoggingSession` to record Binance client requests with masked API key and signature length
- inject `LoggingSession` into bot while preserving proxy support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89be2244c832d82b2a9e404220d66