### PR TITLE
feat: add strategy dispatcher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ SYMBOL=DOGEUSDT
 SR_TIMEFRAME=4h
 STRATEGY=breakout
 BINANCE_TESTNET=false
+# Estrategia de apertura de órdenes:
+# Valores soportados: breakout (default), random_open
+STRATEGY_NAME=breakout

--- a/src/core/execution.py
+++ b/src/core/execution.py
@@ -11,7 +11,7 @@ from binance.exceptions import BinanceAPIException
 from analysis.resistance_levels import next_resistances
 from analysis.support_levels import next_supports
 from analysis.sr_levels import get_sr_levels
-from strategies import detectar_breakout
+from strategies import generate_signal
 
 from .logging_utils import logger, log, debug_log
 from .positions import get_current_position_info, has_active_position
@@ -1310,7 +1310,7 @@ def _run_iteration(exchange, bot, testnet, symbol, leverage=None):
         else:
             log("Orden pendiente detectada, esperando ejecución o cancelación.")
     else:
-        side, level, patterns, rango = detectar_breakout(exchange, symbol)
+        side, level, patterns, rango = generate_signal(exchange, symbol)
         if side:
             order_price = level * 0.999 if side == "buy" else level * 1.001
             if order_price is None or order_price <= 0:

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,6 +1,24 @@
-"""Trading strategies package."""
+import os
+from typing import Any
+from . import breakout as _breakout
+from . import random_open as _random
 
-from .breakout import detectar_breakout
+_SUPPORTED = {
+    "breakout": _breakout,
+    "random_open": _random,
+    "random": _random,  # alias opcional
+}
 
-__all__ = ["detectar_breakout"]
+def _strategy_name() -> str:
+    return os.getenv("STRATEGY_NAME", "breakout").strip().lower()
 
+def generate_signal(*args: Any, **kwargs: Any):
+    """
+    Punto único de entrada de estrategia.
+    Despacha en cada llamada según STRATEGY_NAME (runtime, no build).
+    """
+    mod = _SUPPORTED.get(_strategy_name(), _breakout)
+    fn = getattr(mod, "generate_signal")
+    return fn(*args, **kwargs)
+
+__all__ = ["generate_signal"]

--- a/src/strategies/breakout.py
+++ b/src/strategies/breakout.py
@@ -24,7 +24,7 @@ def _last_swing_low(ohlcv, window=ANALYSIS_WINDOW):
     return None
 
 
-def detectar_breakout(exchange, symbol, window=ANALYSIS_WINDOW):
+def generate_signal(exchange, symbol, window=ANALYSIS_WINDOW):
     """Busca rupturas de los últimos máximos o mínimos en 15m y 30m."""
     for tf in ["15m", "30m"]:
         try:

--- a/src/strategies/random_open.py
+++ b/src/strategies/random_open.py
@@ -12,8 +12,10 @@ ANALYSIS_WINDOW = 12
 _seeded = False
 
 
-def detectar_breakout(exchange: Any, symbol: str, window: int = ANALYSIS_WINDOW, *args: Any, **kwargs: Any):
-    """Genera una señal aleatoria compatible con ``detectar_breakout`` original."""
+def generate_signal(
+    exchange: Any, symbol: str, window: int = ANALYSIS_WINDOW, *args: Any, **kwargs: Any
+):
+    """Genera una señal aleatoria compatible con la estrategia original."""
     global _seeded
     if not _seeded:
         seed = os.getenv("RANDOM_STRATEGY_SEED")


### PR DESCRIPTION
## Summary
- add dynamic strategy dispatcher driven by STRATEGY_NAME env var
- document STRATEGY_NAME in env example
- unify strategy entrypoint to `generate_signal` across codebase

## Testing
- `pytest -q`
- `grep -R "detectar_breakout" -n src tests || true`
- `PYTHONPATH=src python - <<'PY'
import os
from strategies import generate_signal
class Dummy:
    def futures_klines(self, *a, **k): return []
    def fetch_ticker(self, *a, **k): return {}
    def futures_mark_price(self, *a, **k): return {}

dummy = Dummy()
os.environ.pop('STRATEGY_NAME', None)
print('default', generate_signal(dummy, 'BTC/USDT'))
os.environ['STRATEGY_NAME'] = 'random_open'
print('random', generate_signal(dummy, 'BTC/USDT'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68acc13dce88832db0ef8fffd2407e19