### PR TITLE
Define core interfaces and settings scaffolding

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    STRATEGY_NAME: str = "breakout"
+    FEATURE_BROKER: str = "binance"
+    FEATURE_DATASOURCE: str = "binance"
+
+    SYMBOL: str = "BTCUSDT"
+    INTERVAL: str = "1h"
+
+    BINANCE_API_KEY: str | None = None
+    BINANCE_API_SECRET: str | None = None
+
+    LOG_LEVEL: str = "INFO"
+    PAPER_TRADING: bool = True
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+
+@lru_cache
+def load_settings() -> Settings:
+    """Factory function to load settings from environment or .env file."""
+    return Settings()

--- a/src/core/application/execution.py
+++ b/src/core/application/execution.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+
+from config.settings import load_settings
+
+logger = logging.getLogger(__name__)
+
+
+def run_iteration(now: datetime | None = None) -> dict[str, object]:
+    """Execute a single iteration of the bot orchestration."""
+    current_time = now or datetime.utcnow()
+    settings = load_settings()
+    logger.info("Running iteration for %s at %s", settings.STRATEGY_NAME, current_time.isoformat())
+    return {"ok": True, "strategy": settings.STRATEGY_NAME}

--- a/src/core/ports/broker.py
+++ b/src/core/ports/broker.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.domain.models.Order import Order
+    from core.domain.models.Position import Position
+
+
+class Broker(Protocol):
+    """Abstract broker used by strategies to interact with the market."""
+
+    # Reading state
+    def get_positions(self) -> list["Position"]:
+        ...
+
+    def get_open_orders(self) -> list["Order"]:
+        ...
+
+    # Order management
+    def place_order(self, order: "Order") -> str:
+        """Place a new order and return the created order id."""
+        ...
+
+    def cancel_order(self, id: str) -> None:
+        ...
+
+    # Configuration helpers
+    def set_leverage(self, symbol: str, leverage: int) -> None:
+        ...
+
+    def set_margin_mode(self, symbol: str, mode: str) -> None:
+        ...

--- a/src/core/ports/market_data.py
+++ b/src/core/ports/market_data.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.domain.models.Candle import Candle
+
+
+class MarketData(Protocol):
+    """Data provider interface."""
+
+    def get_klines(self, symbol: str, interval: str, limit: int) -> list["Candle"]:
+        ...
+
+    def get_price(self, symbol: str) -> float:
+        ...

--- a/src/core/ports/repositories.py
+++ b/src/core/ports/repositories.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.domain.models.Order import Order
+    from core.domain.models.Position import Position
+
+
+class OrderRepository(Protocol):
+    def save(self, order: "Order") -> None:
+        ...
+
+    def get(self, id: str) -> "Order | None":
+        ...
+
+
+class PositionRepository(Protocol):
+    def save(self, position: "Position") -> None:
+        ...
+
+    def get(self, id: str) -> "Position | None":
+        ...

--- a/src/core/ports/settings.py
+++ b/src/core/ports/settings.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class SettingsProvider(Protocol):
+    """Generic provider for configuration values."""
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        ...

--- a/src/core/ports/strategy.py
+++ b/src/core/ports/strategy.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checking only
+    from core.domain.models.Signal import Signal
+
+
+class Strategy(Protocol):
+    """Interface for trading strategies."""
+
+    def generate_signal(self, now: datetime) -> "Signal | None":
+        """Generate a trading signal for the given time."""
+        ...

--- a/src/runners/lambda_handler.py
+++ b/src/runners/lambda_handler.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from core.application.execution import run_iteration
+
+
+def handler(event=None, context=None):  # pragma: no cover - entry point
+    return run_iteration()

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+# Registry for available strategies. Strategies will be registered here in the
+# future when they are implemented.
+STRATEGY_REGISTRY: dict[str, type] = {}
+
+# TODO: register strategies such as `breakout` when available.


### PR DESCRIPTION
## Summary
- Introduce Protocol-based ports for strategies, broker, data, repositories and settings
- Add typed configuration using `pydantic-settings` with loader factory
- Provide basic application orchestrator, lambda entrypoint, and strategy registry stub

## Testing
- `pip install pydantic-settings` *(fails: Could not find a version that satisfies the requirement pydantic-settings)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'core.execution')*

------
https://chatgpt.com/codex/tasks/task_e_68ba403a3718832d920533b179eeb204