### PR TITLE
Refactor breakout strategy into Strategy interface

### DIFF
--- a/src/core/application/execution.py
+++ b/src/core/application/execution.py
@@ -3,14 +3,43 @@ from __future__ import annotations
 from datetime import datetime
 import logging
 
-from config.settings import load_settings
+from adapters.brokers.binance import make_broker
+from adapters.data_providers.binance import make_market_data
+from config.settings import load_settings, Settings
+from strategies import STRATEGY_REGISTRY
 
 logger = logging.getLogger(__name__)
 
 
+def _resolve_market_data(settings: Settings):
+    if settings.FEATURE_DATASOURCE == "binance":
+        return make_market_data(settings)
+    raise ValueError(f"Unsupported datasource: {settings.FEATURE_DATASOURCE}")
+
+
+def _resolve_broker(settings: Settings):
+    if settings.FEATURE_BROKER == "binance":
+        return make_broker(settings)
+    raise ValueError(f"Unsupported broker: {settings.FEATURE_BROKER}")
+
+
 def run_iteration(now: datetime | None = None) -> dict[str, object]:
     """Execute a single iteration of the bot orchestration."""
+
     current_time = now or datetime.utcnow()
     settings = load_settings()
-    logger.info("Running iteration for %s at %s", settings.STRATEGY_NAME, current_time.isoformat())
-    return {"ok": True, "strategy": settings.STRATEGY_NAME}
+    logger.info(
+        "Running iteration for %s at %s", settings.STRATEGY_NAME, current_time.isoformat()
+    )
+
+    market_data = _resolve_market_data(settings)
+    broker = _resolve_broker(settings)
+
+    strategy_cls = STRATEGY_REGISTRY[settings.STRATEGY_NAME]
+    strategy = strategy_cls(
+        market_data=market_data, broker=broker, settings=settings
+    )
+
+    signal = strategy.generate_signal(current_time)
+
+    return {"ok": True, "strategy": settings.STRATEGY_NAME, "signal": signal}

--- a/src/core/domain/models/Signal.py
+++ b/src/core/domain/models/Signal.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class Signal:
+    """Minimal trading signal produced by strategies."""
+
+    action: str
+    price: float
+    time: datetime

--- a/src/runners/lambda_handler.py
+++ b/src/runners/lambda_handler.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
+import logging
+
 from core.application.execution import run_iteration
+
+logger = logging.getLogger(__name__)
 
 
 def handler(event=None, context=None):  # pragma: no cover - entry point
-    return run_iteration()
+    """AWS Lambda entry point that delegates to :func:`run_iteration`."""
+    try:
+        result = run_iteration()
+        return {"statusCode": 200, "body": result}
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("Iteration failed: %s", exc)
+        return {"statusCode": 500, "body": {"error": str(exc)}}

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,7 +1,21 @@
 from __future__ import annotations
 
-# Registry for available strategies. Strategies will be registered here in the
-# future when they are implemented.
-STRATEGY_REGISTRY: dict[str, type] = {}
+from importlib import util as _importlib_util
+from pathlib import Path
 
-# TODO: register strategies such as `breakout` when available.
+from .breakout import BreakoutStrategy
+
+STRATEGY_REGISTRY: dict[str, type] = {}
+STRATEGY_REGISTRY["breakout"] = BreakoutStrategy
+
+# Optional: load LiquiditySweepStrategy if present
+_liq_path = Path(__file__).with_name("liquidity-sweep").joinpath("__init__.py")
+if _liq_path.exists():  # pragma: no cover - optional stub
+    spec = _importlib_util.spec_from_file_location("strategies.liquidity_sweep", _liq_path)
+    if spec and spec.loader:
+        _module = _importlib_util.module_from_spec(spec)
+        spec.loader.exec_module(_module)
+        if hasattr(_module, "LiquiditySweepStrategy"):
+            STRATEGY_REGISTRY["liquidity-sweep"] = getattr(_module, "LiquiditySweepStrategy")
+
+__all__ = ["STRATEGY_REGISTRY", "BreakoutStrategy"]

--- a/src/strategies/breakout/__init__.py
+++ b/src/strategies/breakout/__init__.py
@@ -1,0 +1,3 @@
+from .impl import BreakoutStrategy
+
+__all__ = ["BreakoutStrategy"]

--- a/src/strategies/breakout/impl.py
+++ b/src/strategies/breakout/impl.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Breakout trading strategy implementation.
+
+This class wraps the previous breakout logic and exposes it through the
+:class:`core.ports.strategy.Strategy` interface. Network or exchange access is
+performed exclusively via the injected ports.
+"""
+
+from datetime import datetime
+from typing import Any
+
+from core.domain.models.Signal import Signal
+from core.ports.broker import Broker as BrokerPort
+from core.ports.market_data import MarketData as MarketDataPort
+from core.ports.strategy import Strategy
+from config.settings import Settings
+
+
+class BreakoutStrategy(Strategy):
+    """Simple breakout strategy based on the latest two candles."""
+
+    def __init__(
+        self,
+        market_data: MarketDataPort,
+        broker: BrokerPort,
+        settings: Settings,
+        repositories: Any | None = None,
+    ) -> None:
+        self._market_data = market_data
+        self._broker = broker
+        self._settings = settings
+        self._repositories = repositories
+
+    # ------------------------------------------------------------------
+    def generate_signal(self, now: datetime) -> Signal | None:
+        """Generate a trading signal at ``now``.
+
+        The strategy compares the latest candle close with the previous
+        candle's high and low. A breakout above the previous high produces a
+        ``BUY`` signal; a breakdown below the previous low produces a ``SELL``
+        signal. If neither condition is met, ``None`` is returned.
+        """
+
+        symbol = self._settings.SYMBOL
+        interval = self._settings.INTERVAL
+
+        candles = self._market_data.get_klines(symbol=symbol, interval=interval, limit=2)
+        if len(candles) < 2:
+            return None
+
+        prev, last = candles[-2], candles[-1]
+        prev_high = float(prev[2])
+        prev_low = float(prev[3])
+        last_close = float(last[4])
+
+        action: str | None = None
+        if last_close > prev_high:
+            action = "BUY"
+        elif last_close < prev_low:
+            action = "SELL"
+
+        if action is None:
+            return None
+
+        price = self._market_data.get_price(symbol)
+        return Signal(action=action, price=price, time=now)

--- a/src/strategies/liquidity-sweep/__init__.py
+++ b/src/strategies/liquidity-sweep/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from core.ports.strategy import Strategy
+
+
+class LiquiditySweepStrategy(Strategy):
+    """Placeholder strategy that currently produces no signals."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def generate_signal(self, now: datetime):  # type: ignore[override]
+        return None
+
+__all__ = ["LiquiditySweepStrategy"]


### PR DESCRIPTION
## Summary
- implement `BreakoutStrategy` that uses broker and market data ports
- register strategies in central `STRATEGY_REGISTRY`
- wire orchestration `run_iteration` and add lambda handler error handling

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core.execution')*

------
https://chatgpt.com/codex/tasks/task_e_68ba441b03e8832d96fddfa0b46cc2d7