### PR TITLE
Add centralized logging and Lambda execution banners

### DIFF
--- a/src/adapters/__init__.py
+++ b/src/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Adapters package."""

--- a/src/adapters/brokers/__init__.py
+++ b/src/adapters/brokers/__init__.py
@@ -1,0 +1,1 @@
+"""Broker adapters."""

--- a/src/adapters/data_providers/__init__.py
+++ b/src/adapters/data_providers/__init__.py
@@ -1,0 +1,1 @@
+"""Data provider adapters."""

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration package."""

--- a/src/config/logging.py
+++ b/src/config/logging.py
@@ -1,0 +1,23 @@
+import logging
+import sys
+from typing import Literal
+
+
+def setup_logging(level: str = "INFO", mode: Literal["plain", "json"] = "plain") -> None:
+    """Configure basic logging for the application."""
+    root = logging.getLogger()
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    handler = logging.StreamHandler(sys.stdout)
+    if mode == "json":
+        formatter = logging.Formatter(
+            '{"level":"%(levelname)s","time":"%(asctime)s","name":"%(name)s","msg":"%(message)s"}',
+            datefmt="%Y-%m-%dT%H:%M:%S%z",
+        )
+    else:
+        formatter = logging.Formatter("%(levelname)s - %(message)s")
+
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+    root.setLevel(level)

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core package."""

--- a/src/core/application/__init__.py
+++ b/src/core/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application layer."""

--- a/src/core/domain/__init__.py
+++ b/src/core/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Domain package."""

--- a/src/core/domain/models/__init__.py
+++ b/src/core/domain/models/__init__.py
@@ -1,0 +1,1 @@
+"""Domain models."""

--- a/src/core/domain/services/__init__.py
+++ b/src/core/domain/services/__init__.py
@@ -1,0 +1,1 @@
+"""Domain services."""

--- a/src/core/ports/__init__.py
+++ b/src/core/ports/__init__.py
@@ -1,0 +1,1 @@
+"""Port definitions."""

--- a/src/runners/__init__.py
+++ b/src/runners/__init__.py
@@ -1,0 +1,1 @@
+"""Runners package."""

--- a/src/runners/lambda_handler.py
+++ b/src/runners/lambda_handler.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import logging
+import os
 
+from config.logging import setup_logging
+from config.settings import load_settings
 from core.application.execution import run_iteration
 
 logger = logging.getLogger(__name__)
@@ -9,9 +12,29 @@ logger = logging.getLogger(__name__)
 
 def handler(event=None, context=None):  # pragma: no cover - entry point
     """AWS Lambda entry point that delegates to :func:`run_iteration`."""
+    settings = load_settings()
+    setup_logging(level=settings.LOG_LEVEL, mode="plain")
+
+    logger.info(
+        "══════════════════ 🚀🚀🚀 INICIO EJECUCIÓN LAMBDA 🚀🚀🚀 ═══════════════════"
+    )
+
+    if os.getenv("USE_PROXY"):
+        logger.info("Proxy: ENABLED (HTTP proxy)")
+    else:
+        logger.info("Proxy: DISABLED (NAT)")
+
     try:
         result = run_iteration()
-        return {"statusCode": 200, "body": result}
+        status = 200
+        body = result
     except Exception as exc:  # pragma: no cover - defensive
-        logger.exception("Iteration failed: %s", exc)
-        return {"statusCode": 500, "body": {"error": str(exc)}}
+        logger.exception("Fallo en iteración: %s", exc)
+        status = 500
+        body = {"error": str(exc)}
+    finally:
+        logger.info(
+            "══════════════════ 🛑🛑🛑 FIN EJECUCIÓN LAMBDA 🛑🛑🛑 ═══════════════════"
+        )
+
+    return {"statusCode": status, "body": body}


### PR DESCRIPTION
## Summary
- centralize logging configuration with plain/JSON formatting
- initialize Lambda handler logging with execution banners and proxy status
- add missing __init__ files to treat directories as packages

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'core.execution')*

------
https://chatgpt.com/codex/tasks/task_e_68bc4af9fef0832d82e0a332933135f6