### PR TITLE
Add instrumentation logs to orchestrator

### DIFF
--- a/src/core/ports/market_data.py
+++ b/src/core/ports/market_data.py
@@ -14,3 +14,6 @@ class MarketData(Protocol):
 
     def get_price(self, symbol: str) -> float:
         ...
+
+    def get_server_time_ms(self) -> int:
+        ...


### PR DESCRIPTION
## Summary
- add `get_server_time_ms` to the market data port
- fetch Binance server time directly with proxies disabled and timeout
- log Binance server vs local clock drift and safety offset in each iteration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.execution')*


------
https://chatgpt.com/codex/tasks/task_e_68bc4cef98f8832d91c32f945cc4a247