### PR TITLE
feat: add detailed logging to breakout

### DIFF
--- a/src/strategies/breakout/impl.py
+++ b/src/strategies/breakout/impl.py
@@ -9,12 +9,15 @@ performed exclusively via the injected ports.
 
 from datetime import datetime
 from typing import Any
+import logging
 
 from core.domain.models.Signal import Signal
 from core.ports.broker import Broker as BrokerPort
 from core.ports.market_data import MarketData as MarketDataPort
 from core.ports.strategy import Strategy
 from config.settings import Settings
+
+logger = logging.getLogger("bot.strategy.breakout")
 
 
 class BreakoutStrategy(Strategy):
@@ -46,13 +49,41 @@ class BreakoutStrategy(Strategy):
         interval = self._settings.INTERVAL
 
         candles = self._market_data.get_klines(symbol=symbol, interval=interval, limit=2)
+        logger.debug("Candles fetched: %s", candles)
         if len(candles) < 2:
+            logger.info("🔎 OBS: %s", "skip:not_enough_candles")
             return None
 
         prev, last = candles[-2], candles[-1]
         prev_high = float(prev[2])
         prev_low = float(prev[3])
         last_close = float(last[4])
+
+        supports = [(prev_low, 1.0)]
+        resistances = [(prev_high, 1.0)]
+        supports_str = ", ".join([f"{p:.6f} (score {s:.2f})" for p, s in supports])
+        resistances_str = ", ".join([f"{p:.6f} (score {s:.2f})" for p, s in resistances])
+        logger.info("🛡️ Soportes estimados: %s", supports_str)
+        logger.info("📚 Resistencias estimadas: %s", resistances_str)
+
+        support_price, support_score = supports[0]
+        resistance_price, resistance_score = resistances[0]
+        support_dist = abs((last_close - support_price) / support_price * 100)
+        resistance_dist = abs((resistance_price - last_close) / resistance_price * 100)
+        logger.info(
+            "🛡️ Próximo soporte: %.6f (score %.2f, dist≈%.2f%%) | razones: %s",
+            support_price,
+            support_score,
+            support_dist,
+            "prev_low",
+        )
+        logger.info(
+            "🧱 Próxima resistencia: %.6f (score %.2f, dist≈%.2f%%) | razones: %s",
+            resistance_price,
+            resistance_score,
+            resistance_dist,
+            "prev_high",
+        )
 
         action: str | None = None
         if last_close > prev_high:
@@ -61,6 +92,7 @@ class BreakoutStrategy(Strategy):
             action = "SELL"
 
         if action is None:
+            logger.info("🔎 OBS: %s", "no_signal")
             return None
 
         price = self._market_data.get_price(symbol)


### PR DESCRIPTION
## Summary
- instrument breakout strategy with named logger `bot.strategy.breakout`
- add informative logs for estimated supports/resistances and skip reasons

## Testing
- `pytest -q` *(fails: /usr/bin/pytest: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc52598720832db800bfccefc66519