### PR TITLE
fix: sanitize Binance symbol

### DIFF
--- a/src/adapters/brokers/binance.py
+++ b/src/adapters/brokers/binance.py
@@ -45,7 +45,8 @@ class BinanceBroker(BrokerPort):
     def get_open_orders(self) -> list["Order"]:
         """Return currently open orders for the configured symbol."""
         try:
-            return self._client.futures_get_open_orders(symbol=self._settings.SYMBOL)  # type: ignore[return-value]
+            sym = self._settings.SYMBOL.replace("/", "")
+            return self._client.futures_get_open_orders(symbol=sym)  # type: ignore[return-value]
         except Exception as exc:  # pragma: no cover - network failures
             logger.error("Failed to fetch open orders: %s", exc)
             raise
@@ -62,7 +63,8 @@ class BinanceBroker(BrokerPort):
     def cancel_order(self, id: str) -> None:
         """Cancel an existing order by id."""
         try:
-            self._client.futures_cancel_order(symbol=self._settings.SYMBOL, orderId=id)
+            sym = self._settings.SYMBOL.replace("/", "")
+            self._client.futures_cancel_order(symbol=sym, orderId=id)
         except Exception as exc:  # pragma: no cover - network failures
             logger.error("Failed to cancel order %s: %s", id, exc)
             raise
@@ -70,7 +72,8 @@ class BinanceBroker(BrokerPort):
     def set_leverage(self, symbol: str, leverage: int) -> None:
         """Set the desired leverage for ``symbol``."""
         try:
-            self._client.futures_change_leverage(symbol=symbol, leverage=leverage)
+            sym = symbol.replace("/", "")
+            self._client.futures_change_leverage(symbol=sym, leverage=leverage)
         except Exception as exc:  # pragma: no cover - network failures
             logger.error("Failed to set leverage for %s: %s", symbol, exc)
             raise
@@ -78,7 +81,8 @@ class BinanceBroker(BrokerPort):
     def set_margin_mode(self, symbol: str, mode: str) -> None:
         """Change the margin mode (cross/isolated)."""
         try:
-            self._client.futures_change_margin_type(symbol=symbol, marginType=mode)
+            sym = symbol.replace("/", "")
+            self._client.futures_change_margin_type(symbol=sym, marginType=mode)
         except Exception as exc:  # pragma: no cover - network failures
             logger.error("Failed to set margin mode for %s: %s", symbol, exc)
             raise

--- a/src/adapters/data_providers/binance.py
+++ b/src/adapters/data_providers/binance.py
@@ -42,9 +42,10 @@ class BinanceMarketData(MarketDataPort):
         domain models are introduced this should be mapped accordingly.
         """
         # TODO: replace with shared retry helper
+        sym = symbol.replace("/", "")
         for attempt in range(3):
             try:
-                return self._client.get_klines(symbol=symbol, interval=interval, limit=limit)  # type: ignore[return-value]
+                return self._client.get_klines(symbol=sym, interval=interval, limit=limit)  # type: ignore[return-value]
             except Exception as exc:  # pragma: no cover - network failures
                 logger.warning(
                     "Binance get_klines failed (attempt %s/3): %s", attempt + 1, exc
@@ -54,9 +55,10 @@ class BinanceMarketData(MarketDataPort):
     def get_price(self, symbol: str) -> float:
         """Return the latest price for ``symbol``."""
         # TODO: replace with shared retry helper
+        sym = symbol.replace("/", "")
         for attempt in range(3):
             try:
-                ticker = self._client.get_symbol_ticker(symbol=symbol)
+                ticker = self._client.get_symbol_ticker(symbol=sym)
                 return float(ticker["price"])
             except Exception as exc:  # pragma: no cover - network failures
                 logger.warning(


### PR DESCRIPTION
## Summary
- sanitize Binance symbol parameter by removing slashes before client calls

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core.execution')*


------
https://chatgpt.com/codex/tasks/task_e_68bc7bfd48ac832da864f6fadfab641d