### PR TITLE
chore: shorten active config log

### DIFF
--- a/src/core/application/execution.py
+++ b/src/core/application/execution.py
@@ -35,7 +35,12 @@ def run_iteration(now: datetime | None = None) -> dict[str, object]:
     )
     logger.info(
         "Active config: %s",
-        settings.model_dump(exclude={"BINANCE_API_KEY", "BINANCE_API_SECRET"}),
+        {
+            "STRATEGY_NAME": settings.STRATEGY_NAME,
+            "FEATURE_BROKER": settings.FEATURE_BROKER,
+            "SYMBOL": settings.SYMBOL,
+            "INTERVAL": settings.INTERVAL,
+        },
     )
 
     market_data = _resolve_market_data(settings)


### PR DESCRIPTION
## Summary
- shorten Active config log to essential fields only

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.execution')*


------
https://chatgpt.com/codex/tasks/task_e_68bc8410425c832d965a1c78261846f8