### PR TITLE
Add liquidity sweep strategy skeleton

### DIFF
--- a/src/strategies/liquidity_sweep/__init__.py
+++ b/src/strategies/liquidity_sweep/__init__.py
@@ -1,0 +1,3 @@
+from .strategy import LiquiditySweepStrategy, generateSignal
+
+__all__ = ["LiquiditySweepStrategy", "generateSignal"]

--- a/src/strategies/liquidity_sweep/strategy.py
+++ b/src/strategies/liquidity_sweep/strategy.py
@@ -1,0 +1,89 @@
+"""Liquidity sweep strategy skeleton.
+
+This module provides a minimal implementation of the Liquidity Sweep
+strategy.  It intentionally keeps side effects out of module import time and
+splits pure computations from IO operations.  The goal is to serve as a
+starting point for a more complete implementation.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Iterable, Mapping
+
+
+# ---------------------------------------------------------------------------
+# Pure helper functions
+
+
+def compute_levels(order_book: Any, *args: Any, **kwargs: Any) -> list:
+    """Return estimated liquidity levels from ``order_book``.
+
+    This function is pure: its output depends only on its inputs and it
+    performs no IO.
+    """
+    return []
+
+
+def build_entry_prices(levels: Iterable[Any], *args: Any, **kwargs: Any) -> list:
+    """Derive entry prices from previously computed ``levels``.
+
+    This function is pure and performs no IO.
+    """
+    return []
+
+
+def build_bracket(entry_price: float, stop_loss: float, take_profit: float, *args: Any, **kwargs: Any) -> dict:
+    """Construct a bracket order description.
+
+    Pure function that returns a dictionary describing the bracket
+    configuration.
+    """
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Internal IO helpers
+
+
+def do_preopen(exchange: Any, now_utc: datetime | None = None) -> dict:
+    """Perform pre-open IO actions.
+
+    This function encapsulates side effects required before the market
+    opens.
+    """
+    return {}
+
+
+def do_tick(exchange: Any, now_utc: datetime | None = None, event: Any | None = None) -> dict:
+    """Perform IO actions for a regular tick/event."""
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Strategy
+
+
+class LiquiditySweepStrategy:
+    """High level strategy coordinator."""
+
+    def run(self, exchange: Any, now_utc: datetime | None = None, event: Any | None = None) -> dict:
+        """Execute the strategy and return a result dictionary."""
+        if event == "preopen":
+            return do_preopen(exchange, now_utc)
+        return do_tick(exchange, now_utc, event)
+
+
+# ---------------------------------------------------------------------------
+# Legacy compatibility
+
+
+def generateSignal(context: Mapping[str, Any]) -> dict:
+    """Legacy compatibility wrapper.
+
+    ``context`` is expected to provide ``exchange``, ``now_utc`` and ``event``
+    items.  The function delegates to :meth:`LiquiditySweepStrategy.run`.
+    """
+    exchange = context.get("exchange")
+    now_utc = context.get("now_utc")
+    event = context.get("event")
+    return LiquiditySweepStrategy().run(exchange, now_utc=now_utc, event=event)


### PR DESCRIPTION
## Summary
- scaffold liquidity sweep strategy with pure and IO helpers
- expose legacy generateSignal wrapper

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core.execution')*

------
https://chatgpt.com/codex/tasks/task_e_68bca3b6dc88832dbe23220cfc0c41fc