### PR TITLE
feat: add NY time gating to liquidity sweep

### DIFF
--- a/src/strategies/liquidity_sweep/strategy.py
+++ b/src/strategies/liquidity_sweep/strategy.py
@@ -7,8 +7,12 @@ starting point for a more complete implementation.
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Iterable, Mapping
+from zoneinfo import ZoneInfo
+
+
+TIMEOUT_NO_FILL_MIN = 5  # minutes after NY open to keep processing ticks
 
 
 # ---------------------------------------------------------------------------
@@ -66,11 +70,43 @@ def do_tick(exchange: Any, now_utc: datetime | None = None, event: Any | None = 
 class LiquiditySweepStrategy:
     """High level strategy coordinator."""
 
-    def run(self, exchange: Any, now_utc: datetime | None = None, event: Any | None = None) -> dict:
+    def run(
+        self, exchange: Any, now_utc: datetime | None = None, event: Any | None = None
+    ) -> dict:
         """Execute the strategy and return a result dictionary."""
-        if event == "preopen":
-            return do_preopen(exchange, now_utc)
-        return do_tick(exchange, now_utc, event)
+        utc_now = now_utc or datetime.now(tz=ZoneInfo("UTC"))
+        ny_now = utc_now.astimezone(ZoneInfo("America/New_York"))
+
+        open_at_epoch_ms = None
+        force_phase = None
+        if isinstance(event, Mapping):
+            open_at_epoch_ms = event.get("open_at_epoch_ms")
+            force_phase = event.get("force_phase")
+        else:
+            open_at_epoch_ms = getattr(event, "open_at_epoch_ms", None)
+            force_phase = getattr(event, "force_phase", None)
+            if isinstance(event, str) and event in {"preopen", "tick"}:
+                force_phase = event
+
+        if open_at_epoch_ms is not None:
+            open_at_ny = datetime.fromtimestamp(open_at_epoch_ms / 1000, tz=ZoneInfo("UTC")).astimezone(
+                ZoneInfo("America/New_York")
+            )
+        else:
+            open_at_ny = ny_now.replace(hour=9, minute=30, second=0, microsecond=0)
+
+        preopen_start = open_at_ny - timedelta(minutes=5)
+        preopen_end = open_at_ny
+        tick_start = open_at_ny
+        tick_end = open_at_ny + timedelta(minutes=TIMEOUT_NO_FILL_MIN)
+
+        if force_phase == "preopen" or preopen_start <= ny_now < preopen_end:
+            return do_preopen(exchange, utc_now)
+
+        if force_phase == "tick" or tick_start <= ny_now < tick_end:
+            return do_tick(exchange, utc_now, event)
+
+        return {"status": "idle", "reason": "out_of_window"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- gate LiquiditySweepStrategy by New York pre-open and tick windows
- allow event overrides for market open time and phase

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.execution')*

------
https://chatgpt.com/codex/tasks/task_e_68bca4b8ba18832d80049d80fd699aa8