### PR TITLE
Add default settings parameters and provider accessors

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from typing import Any
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -12,6 +14,14 @@ class Settings(BaseSettings):
     FEATURE_DATASOURCE: str = "binance"
 
     SYMBOL: str = "BTCUSDT"
+    RISK_PCT: float = 0.003
+    TIMEOUT_NO_FILL_MIN: int = 20
+    MICROBUFFER_PCT_MIN: float = 0.0002
+    MICROBUFFER_ATR1M_MULT: float = 0.25
+    BUFFER_SL_PCT_MIN: float = 0.0005
+    BUFFER_SL_ATR1M_MULT: float = 0.5
+    TP_POLICY: str = "STRUCTURAL_OR_1_8R"
+    MAX_LOOKBACK_MIN: int = 60
     INTERVAL: str = "1h"
 
     BINANCE_API_KEY: str | None = None
@@ -21,6 +31,10 @@ class Settings(BaseSettings):
     PAPER_TRADING: bool = True
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        """Return configuration value for ``key`` with ``default`` fallback."""
+        return getattr(self, key, default)
 
 
 @lru_cache

--- a/src/core/ports/settings.py
+++ b/src/core/ports/settings.py
@@ -8,3 +8,47 @@ class SettingsProvider(Protocol):
 
     def get(self, key: str, default: Any | None = None) -> Any:
         ...
+
+
+# ---------------------------------------------------------------------------
+# Helper accessors with defaults
+
+
+def get_symbol(settings: SettingsProvider) -> str:
+    return settings.get("SYMBOL", "BTCUSDT")
+
+
+def get_risk_pct(settings: SettingsProvider) -> float:
+    return float(settings.get("RISK_PCT", 0.003))
+
+
+def get_timeout_no_fill_min(settings: SettingsProvider) -> int:
+    return int(settings.get("TIMEOUT_NO_FILL_MIN", 20))
+
+
+def get_microbuffer_pct_min(settings: SettingsProvider) -> float:
+    return float(settings.get("MICROBUFFER_PCT_MIN", 0.0002))
+
+
+def get_microbuffer_atr1m_mult(settings: SettingsProvider) -> float:
+    return float(settings.get("MICROBUFFER_ATR1M_MULT", 0.25))
+
+
+def get_buffer_sl_pct_min(settings: SettingsProvider) -> float:
+    return float(settings.get("BUFFER_SL_PCT_MIN", 0.0005))
+
+
+def get_buffer_sl_atr1m_mult(settings: SettingsProvider) -> float:
+    return float(settings.get("BUFFER_SL_ATR1M_MULT", 0.5))
+
+
+def get_tp_policy(settings: SettingsProvider) -> str:
+    return settings.get("TP_POLICY", "STRUCTURAL_OR_1_8R")
+
+
+def get_max_lookback_min(settings: SettingsProvider) -> int:
+    return int(settings.get("MAX_LOOKBACK_MIN", 60))
+
+
+def get_log_level(settings: SettingsProvider) -> str:
+    return settings.get("LOG_LEVEL", "INFO")

--- a/src/strategies/breakout/impl.py
+++ b/src/strategies/breakout/impl.py
@@ -15,7 +15,7 @@ from core.domain.models.Signal import Signal
 from core.ports.broker import Broker as BrokerPort
 from core.ports.market_data import MarketData as MarketDataPort
 from core.ports.strategy import Strategy
-from config.settings import Settings
+from core.ports.settings import SettingsProvider, get_symbol
 
 logger = logging.getLogger("bot.strategy.breakout")
 
@@ -27,7 +27,7 @@ class BreakoutStrategy(Strategy):
         self,
         market_data: MarketDataPort,
         broker: BrokerPort,
-        settings: Settings,
+        settings: SettingsProvider,
         repositories: Any | None = None,
     ) -> None:
         self._market_data = market_data
@@ -45,8 +45,8 @@ class BreakoutStrategy(Strategy):
         signal. If neither condition is met, ``None`` is returned.
         """
 
-        symbol = self._settings.SYMBOL
-        interval = self._settings.INTERVAL
+        symbol = get_symbol(self._settings)
+        interval = self._settings.get("INTERVAL", "1h")
 
         candles = self._market_data.get_klines(symbol=symbol, interval=interval, limit=2)
         logger.debug("Candles fetched: %s", candles)


### PR DESCRIPTION
## Summary
- add default risk, buffer, timeout, and policy parameters to settings
- expose helper getters in SettingsProvider for configuration defaults
- update breakout strategy to read settings via SettingsProvider

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.execution')*


------
https://chatgpt.com/codex/tasks/task_e_68bca5a99d64832dbc69f8dd7b4e6b8f