### PR TITLE
feat: implement liquidity sweep preopen logic

### DIFF
--- a/src/strategies/liquidity_sweep/strategy.py
+++ b/src/strategies/liquidity_sweep/strategy.py
@@ -8,6 +8,7 @@ starting point for a more complete implementation.
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from math import floor
 from typing import Any, Iterable, Mapping
 from zoneinfo import ZoneInfo
 
@@ -22,10 +23,25 @@ TIMEOUT_NO_FILL_MIN = 5  # minutes after NY open to keep processing ticks
 def compute_levels(order_book: Any, *args: Any, **kwargs: Any) -> list:
     """Return estimated liquidity levels from ``order_book``.
 
-    This function is pure: its output depends only on its inputs and it
-    performs no IO.
+    This function is a placeholder.  A real implementation should analyse
+    ``order_book`` and return a mapping with support/resistance levels plus
+    auxiliary values such as ATR and buffers.  The :func:`do_preopen`
+    implementation expects a dictionary with at least the following keys::
+
+        {
+            "S": float,              # Support level
+            "R": float,              # Resistance level
+            "atr1m": float,
+            "atr15m": float,
+            "microbuffer": float,   # Entry buffer
+            "buffer_sl": float,     # Stop loss buffer
+        }
+
+    For the scope of this kata the function simply returns an empty dict so
+    that :func:`do_preopen` can be exercised in isolation.
     """
-    return []
+
+    return {}
 
 
 def build_entry_prices(levels: Iterable[Any], *args: Any, **kwargs: Any) -> list:
@@ -49,13 +65,100 @@ def build_bracket(entry_price: float, stop_loss: float, take_profit: float, *arg
 # Internal IO helpers
 
 
-def do_preopen(exchange: Any, now_utc: datetime | None = None) -> dict:
+def do_preopen(exchange: Any, symbol: str, settings: Any) -> dict:
     """Perform pre-open IO actions.
 
-    This function encapsulates side effects required before the market
-    opens.
+    The function fetches recent candle data to compute support and resistance
+    levels and places two idempotent LIMIT orders around those levels.  Existing
+    orders are updated only if the new price differs by more than one tick.
+
+    Parameters
+    ----------
+    exchange:
+        Object providing market-data and trading capabilities.  It must expose
+        ``get_klines``/``fetch_ohlcv`` for candles, ``open_orders`` to query
+        current orders, ``place_limit`` and ``cancel_order`` to manage orders as
+        well as helpers ``get_symbol_filters`` and ``round_price_to_tick``.
+    symbol:
+        Market symbol, e.g. ``"BTCUSDT"``.
+    settings:
+        Configuration container providing at least ``MAX_LOOKBACK_MIN``.
+
+    Returns
+    -------
+    dict
+        Summary of the pre-open step containing the computed prices and the
+        ``trade_id`` used for idempotency.
     """
-    return {}
+
+    lookback = getattr(settings, "MAX_LOOKBACK_MIN", 60)
+
+    # ------------------------------------------------------------------
+    # Fetch 1m candles
+    if hasattr(exchange, "get_klines"):
+        candles = exchange.get_klines(symbol=symbol, interval="1m", lookback_min=lookback)
+    else:  # pragma: no cover - fallback for exchanges exposing ccxt-like API
+        candles = exchange.fetch_ohlcv(symbol, timeframe="1m", limit=lookback)  # type: ignore[attr-defined]
+
+    levels: Mapping[str, float] = compute_levels(candles, settings=settings) or {}
+    S = float(levels.get("S", 0.0))
+    R = float(levels.get("R", 0.0))
+    microbuffer = float(levels.get("microbuffer", 0.0))
+
+    buy_px = S + microbuffer
+    sell_px = R - microbuffer
+
+    # Determine tick size to align prices and to evaluate changes
+    tick = 0.0
+    try:
+        filters = exchange.get_symbol_filters(symbol)
+        tick = float(filters["PRICE_FILTER"]["tickSize"])
+    except Exception:  # pragma: no cover - helper not available
+        pass
+
+    if hasattr(exchange, "round_price_to_tick"):
+        buy_px = exchange.round_price_to_tick(symbol, buy_px)
+        sell_px = exchange.round_price_to_tick(symbol, sell_px)
+    elif tick:  # pragma: no cover - manual rounding when helper missing
+        buy_px = floor(buy_px / tick) * tick
+        sell_px = floor(sell_px / tick) * tick
+
+    # ------------------------------------------------------------------
+    # Build client order ids
+    ny_now = datetime.now(tz=ZoneInfo("America/New_York"))
+    trade_id = f"{symbol}-{ny_now.strftime('%Y%m%d')}-NY"
+    cid_buy = f"{trade_id}:pre:buy"
+    cid_sell = f"{trade_id}:pre:sell"
+
+    qty = 1.0
+    if hasattr(exchange, "round_qty_to_step"):
+        qty = exchange.round_qty_to_step(symbol, qty)
+
+    open_orders = exchange.open_orders(symbol)
+
+    def _ensure_limit(side: str, price: float, cid: str) -> None:
+        existing = next((o for o in open_orders if o.get("clientOrderId") == cid), None)
+        if existing:
+            try:
+                current_price = float(existing.get("price", 0.0))
+            except Exception:  # pragma: no cover
+                current_price = 0.0
+            if tick and abs(current_price - price) <= tick:
+                return
+            exchange.cancel_order(symbol, clientOrderId=cid)
+        exchange.place_limit(symbol, side, price, qty, cid, timeInForce="GTC")
+
+    _ensure_limit("BUY", buy_px, cid_buy)
+    _ensure_limit("SELL", sell_px, cid_sell)
+
+    return {
+        "status": "preopen_ok",
+        "trade_id": trade_id,
+        "S": S,
+        "R": R,
+        "buy_px": buy_px,
+        "sell_px": sell_px,
+    }
 
 
 def do_tick(exchange: Any, now_utc: datetime | None = None, event: Any | None = None) -> dict:


### PR DESCRIPTION
## Summary
- implement `do_preopen` to place idempotent LIMIT orders around computed S/R levels
- document placeholder `compute_levels` return structure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.execution')*


------
https://chatgpt.com/codex/tasks/task_e_68bcaa46ded4832da81ac80fd01bceec