### PR TITLE
Ensure Binance client API key header

### DIFF
--- a/src/adapters/brokers/binance.py
+++ b/src/adapters/brokers/binance.py
@@ -50,7 +50,11 @@ class BinanceBroker(BrokerPort):
             testnet=settings.BINANCE_TESTNET,
             requests_params=requests_params,
         )
-        self._client.session = getattr(self, "_session", None)
+        _api_key = getattr(self._client, "API_KEY", None) or getattr(
+            self._client, "api_key", None
+        )
+        if _api_key:
+            self._client.session.headers.setdefault("X-MBX-APIKEY", _api_key)
         
         # Cache for symbol filters to avoid repeated ``exchangeInfo`` calls
         self._filters_cache: Dict[str, Dict[str, Any]] = {}


### PR DESCRIPTION
## Summary
- Avoid overriding Binance client's session so headers persist
- Ensure X-MBX-APIKEY is set once on client session

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.execution')*


------
https://chatgpt.com/codex/tasks/task_e_68bf87b02a04832d8862e9b899c4d8c0