### PR TITLE
Fix undefined variables in liquidity sweep preopen

### DIFF
--- a/src/strategies/liquidity_sweep/strategy.py
+++ b/src/strategies/liquidity_sweep/strategy.py
@@ -335,6 +335,8 @@ def do_preopen(exchange: Any, market_data: Any, symbol: str, settings: Any) -> d
     S = float(levels.get("S", 0.0))
     R = float(levels.get("R", 0.0))
     microbuffer = float(levels.get("microbuffer", 0.0))
+    buffer_sl = float(levels.get("buffer_sl", 0.0))
+    atr1m = float(levels.get("atr1m", 0.0))
 
     buy_px = S + microbuffer
     sell_px = R - microbuffer


### PR DESCRIPTION
## Summary
- retrieve `buffer_sl` and `atr1m` values in `do_preopen` to avoid NameError when building brackets

## Testing
- `PYTHONPATH=src pytest -q` *(fails: No module named 'pydantic_settings'; No module named 'core.execution')*

------
https://chatgpt.com/codex/tasks/task_e_68c08f663810832dbf6a5fe408de065a