### PR TITLE
feat(config): support STRATEGY alias

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -5,13 +5,14 @@ from typing import Any
 import logging
 import os
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
-    STRATEGY_NAME: str = "breakout"
+    STRATEGY_NAME: str = Field(default="breakout", alias="STRATEGY")
     FEATURE_BROKER: str = "binance"
     FEATURE_DATASOURCE: str = "binance"
 


### PR DESCRIPTION
## Summary
- import Field from pydantic and set `STRATEGY_NAME` with alias `STRATEGY`

## Testing
- `pip install -r requirements.txt pydantic pydantic-settings` (fails: Could not connect to proxy)
- `pytest` (fails: ModuleNotFoundError: No module named 'pydantic')

------
https://chatgpt.com/codex/tasks/task_e_68c1b3881830832d8afd7234146fbc8a