### PR TITLE
feat: add CR hook stub for breakout strategy

### DIFF
--- a/src/strategies/breakout/cr_hook.py
+++ b/src/strategies/breakout/cr_hook.py
@@ -1,0 +1,39 @@
+import logging
+
+
+def run_cr_on_open_position(ctx, symbol: str, position: dict, logger=None) -> None:
+    """Placeholder hook for collateral/CR management when a position is open.
+
+    Parameters
+    ----------
+    ctx: Any
+        Execution context, passed through for future use.
+    symbol: str
+        Trading symbol (e.g., ``"BTCUSDT"``).
+    position: dict
+        Information about the currently open position.
+    logger: logging.Logger | None
+        Optional logger instance. Defaults to the breakout strategy logger.
+    """
+    logger = logger or logging.getLogger("bot.strategy.breakout")
+
+    side = None if position is None else position.get("side")
+    qty = None
+    entry = None
+    if isinstance(position, dict):
+        qty = position.get("positionAmt") or position.get("qty")
+        entry = position.get("entryPrice") or position.get("entry")
+
+    logger.info(
+        "breakout.cr: hook ejecutado (posición abierta); sym=%s side=%s qty=%s entry=%s",
+        symbol,
+        side,
+        qty,
+        entry,
+        extra={"strategy": "breakout", "hook": "cr_on_open", "sym": symbol},
+    )
+
+    # TODO: evaluar SL/TP existentes
+    # TODO: decidir políticas reduceOnly
+    # TODO: idempotencia y actualización
+    return None


### PR DESCRIPTION
## Summary
- add breakout CR hook stub for handling open positions
- invoke hook when breakout detects an existing position

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `PYTHONPATH=src python - <<'PY'
import logging
from strategies.breakout.impl import BreakoutStrategy

class DummyBroker:
    def position_information(self, symbol):
        return {"positionAmt": 1, "entryPrice": 100}

class DummyMarketData:
    pass

class DummySettings(dict):
    def get(self, key, default=None):
        return super().get(key, default)

logging.basicConfig(level=logging.INFO)
settings = DummySettings({"SYMBOL": "BTCUSDT"})
strategy = BreakoutStrategy(market_data=DummyMarketData(), broker=DummyBroker(), settings=settings)
result = strategy.run()
print("result=", result)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c4d0526188832daf300f37a54f8d91