### PR TITLE
Normalize symbols for Binance operations

### DIFF
--- a/src/adapters/brokers/binance.py
+++ b/src/adapters/brokers/binance.py
@@ -14,12 +14,13 @@ from requests import Session
 from config.settings import Settings
 from core.ports.broker import BrokerPort
 from common.utils import sanitize_client_order_id
+from common.symbols import normalize_symbol as _normalize_symbol
 
 logger = logging.getLogger(__name__)
 
 
 def _to_binance_symbol(sym: str) -> str:
-    return sym.replace("/", "")
+    return _normalize_symbol(sym)
 
 
 def _calc_drift_ms(client: Client) -> int:
@@ -100,7 +101,7 @@ class BinanceBroker(BrokerPort):
             testnet=settings.BINANCE_TESTNET,
             requests_params=requests_params,
         )
-        
+
         # Cache for symbol filters to avoid repeated ``exchangeInfo`` calls
         self._filters_cache: Dict[str, Dict[str, Any]] = {}
 
@@ -109,6 +110,10 @@ class BinanceBroker(BrokerPort):
             return "<empty>"
         s = str(s)
         return s[:6] + "…" + s[-4:]
+
+    def normalize_symbol(self, symbol: str) -> str:
+        """Return ``symbol`` uppercased without the ``/`` character."""
+        return _normalize_symbol(symbol)
 
     # ------------------------------------------------------------------
     # Orders

--- a/src/adapters/data_providers/binance.py
+++ b/src/adapters/data_providers/binance.py
@@ -12,6 +12,7 @@ from binance.client import Client
 
 from config.settings import Settings
 from core.ports.market_data import MarketDataPort
+from common.symbols import normalize_symbol
 
 if TYPE_CHECKING:  # pragma: no cover - domain models are not yet implemented
     from core.domain.models.Candle import Candle
@@ -48,7 +49,7 @@ class BinanceMarketData(MarketDataPort):
     def get_klines(self, symbol: str, interval: str, lookback_min: int) -> list["Candle"]:
         """Return OHLC candles for a symbol over ``lookback_min`` minutes."""
 
-        sym = symbol.replace("/", "")
+        sym = normalize_symbol(symbol)
         minutes = _interval_to_minutes(interval)
         limit = max(1, lookback_min // minutes)
         # TODO: replace with shared retry helper
@@ -68,7 +69,7 @@ class BinanceMarketData(MarketDataPort):
         normalized to ``[ms, open, high, low, close, volume]``.
         """
 
-        sym = symbol.replace("/", "")
+        sym = normalize_symbol(symbol)
         for attempt in range(3):
             try:
                 data = self._client.get_klines(symbol=sym, interval=timeframe, limit=limit)
@@ -90,7 +91,7 @@ class BinanceMarketData(MarketDataPort):
         raise RuntimeError("Failed to fetch klines after retries")
 
     def get_price(self, symbol: str) -> float:
-        sym = symbol.replace("/", "")
+        sym = normalize_symbol(symbol)
         for attempt in range(3):
             try:
                 ticker = self._client.get_symbol_ticker(symbol=sym)

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -1,5 +1,6 @@
 """Common utilities."""
 
 from .utils import sanitize_client_order_id
+from .symbols import normalize_symbol
 
-__all__ = ["sanitize_client_order_id"]
+__all__ = ["sanitize_client_order_id", "normalize_symbol"]

--- a/src/common/symbols.py
+++ b/src/common/symbols.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+__all__ = ["normalize_symbol"]
+
+
+def normalize_symbol(symbol: str) -> str:
+    """Return ``symbol`` uppercased without the ``/`` character."""
+    return symbol.replace("/", "").upper()

--- a/src/strategies/breakout/impl.py
+++ b/src/strategies/breakout/impl.py
@@ -16,6 +16,7 @@ from zoneinfo import ZoneInfo
 from math import ceil
 
 from common.utils import sanitize_client_order_id, is_in_blackout
+from common.symbols import normalize_symbol
 from core.domain.models.Signal import Signal
 from core.ports.broker import BrokerPort
 from core.ports.market_data import MarketDataPort
@@ -140,12 +141,13 @@ class BreakoutStrategy(Strategy):
         entry_price = 0.0
         try:
             info: Any | None
+            symbol_n = normalize_symbol(symbol)
             if hasattr(exch, "position_information"):
-                info = exch.position_information(symbol)
+                info = exch.position_information(symbol_n)
             elif hasattr(exch, "futures_position_information"):
-                info = exch.futures_position_information(symbol)
+                info = exch.futures_position_information(symbol_n)
             elif hasattr(exch, "get_position"):
-                info = exch.get_position(symbol)
+                info = exch.get_position(symbol_n)
             else:
                 info = None
             if info is not None:

--- a/src/strategies/liquidity_sweep/strategy.py
+++ b/src/strategies/liquidity_sweep/strategy.py
@@ -15,6 +15,8 @@ import json
 import logging
 from decimal import Decimal
 
+from common.symbols import normalize_symbol
+
 
 TIMEOUT_NO_FILL_MIN = 5  # minutes after NY open to keep processing ticks
 
@@ -317,12 +319,13 @@ def _has_position_or_active_orders(exchange: Any, symbol: str) -> tuple[bool, li
 
     qty = 0.0
     try:
+        symbol_n = normalize_symbol(symbol)
         if hasattr(exchange, "position_information"):
-            info = exchange.position_information(symbol)
+            info = exchange.position_information(symbol_n)
         elif hasattr(exchange, "futures_position_information"):
-            info = exchange.futures_position_information(symbol)
+            info = exchange.futures_position_information(symbol_n)
         elif hasattr(exchange, "get_position"):
-            info = exchange.get_position(symbol)
+            info = exchange.get_position(symbol_n)
         else:
             info = None
 
@@ -828,9 +831,9 @@ def do_tick(
             try:
                 symbol_n = exchange.normalize_symbol(symbol)
             except Exception:
-                symbol_n = symbol.replace("/", "")
+                symbol_n = normalize_symbol(symbol)
         else:
-            symbol_n = symbol.replace("/", "") if "/" in symbol else symbol
+            symbol_n = normalize_symbol(symbol)
 
         try:
             filters = exchange.get_symbol_filters(symbol_n)


### PR DESCRIPTION
## Summary
- add reusable `normalize_symbol` helper
- use normalized symbols in Binance adapters
- ensure strategies query positions with slashless symbols

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic==1.10.13` *(fails: Could not find a version that satisfies the requirement pydantic==1.10.13)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d9bb1938832d87c59ac93ff1a35b