### PR TITLE
feat: manage breakout protective orders

### DIFF
--- a/src/strategies/breakout/cr_hook.py
+++ b/src/strategies/breakout/cr_hook.py
@@ -1,39 +1,141 @@
 import logging
+from uuid import uuid4
+
+from common.utils import sanitize_client_order_id
 
 
 def run_cr_on_open_position(ctx, symbol: str, position: dict, logger=None) -> None:
-    """Placeholder hook for collateral/CR management when a position is open.
+    """Manage protective orders (SL/TP) for an open position."""
 
-    Parameters
-    ----------
-    ctx: Any
-        Execution context, passed through for future use.
-    symbol: str
-        Trading symbol (e.g., ``"BTCUSDT"``).
-    position: dict
-        Information about the currently open position.
-    logger: logging.Logger | None
-        Optional logger instance. Defaults to the breakout strategy logger.
-    """
     logger = logger or logging.getLogger("bot.strategy.breakout")
 
-    side = None if position is None else position.get("side")
-    qty = None
-    entry = None
-    if isinstance(position, dict):
-        qty = position.get("positionAmt") or position.get("qty")
-        entry = position.get("entryPrice") or position.get("entry")
+    exchange = ctx.get("exchange") if ctx else None
+    settings = ctx.get("settings") if ctx else None
+    market_data = ctx.get("market_data") if ctx else None
+
+    sl_pct = float(settings.get("STOP_LOSS_PCT", 0) or 0) if settings else 0.0
+    tp_pct = float(settings.get("TAKE_PROFIT_PCT", 0) or 0) if settings else 0.0
+    logger.info("breakout.cr: pct_params {sl_pct=%s, tp_pct=%s}", sl_pct, tp_pct)
+    if sl_pct <= 0 or tp_pct <= 0:
+        logger.info("breakout.cr: bracket_skipped {reason=pct_missing}")
+        return None
+
+    qty = float(position.get("positionAmt") or position.get("qty") or 0.0)
+    entry = float(position.get("entryPrice") or position.get("entry") or 0.0)
+    side = "LONG" if qty > 0 else "SHORT" if qty < 0 else None
+    exit_side = "SELL" if qty > 0 else "BUY" if qty < 0 else None
+    qty_abs = abs(qty)
+
+    if not entry:
+        try:
+            entry = float(market_data.get_price(symbol)) if market_data else 0.0
+        except Exception:  # pragma: no cover - defensive
+            entry = 0.0
+    if not entry:
+        logger.warning("breakout.cr: bracket_skipped {reason=invalid_entry}")
+        return None
+
+    try:
+        filters = exchange.get_symbol_filters(symbol) if exchange else {}
+        min_qty = float(filters.get("LOT_SIZE", {}).get("minQty", 0.0))
+    except Exception:  # pragma: no cover - defensive
+        min_qty = 0.0
+    if qty_abs < min_qty:
+        logger.info("breakout.cr: bracket_skipped {reason=qty_below_min}")
+        return None
+
+    if qty > 0:  # long
+        sl = entry * (1 - sl_pct / 100.0)
+        tp = entry * (1 + tp_pct / 100.0)
+    else:  # short
+        sl = entry * (1 + sl_pct / 100.0)
+        tp = entry * (1 - tp_pct / 100.0)
+
+    if hasattr(exchange, "round_price_to_tick"):
+        sl = exchange.round_price_to_tick(symbol, sl)
+        tp = exchange.round_price_to_tick(symbol, tp)
+    if hasattr(exchange, "round_qty_to_step"):
+        qty_abs = exchange.round_qty_to_step(symbol, qty_abs)
 
     logger.info(
-        "breakout.cr: hook ejecutado (posición abierta); sym=%s side=%s qty=%s entry=%s",
-        symbol,
+        "breakout.cr: targets {side=%s, entry=%s, sl=%s, tp=%s, qty=%s}",
         side,
-        qty,
         entry,
-        extra={"strategy": "breakout", "hook": "cr_on_open", "sym": symbol},
+        sl,
+        tp,
+        qty_abs,
     )
 
-    # TODO: evaluar SL/TP existentes
-    # TODO: decidir políticas reduceOnly
-    # TODO: idempotencia y actualización
+    try:
+        open_orders = exchange.open_orders(symbol) if exchange else []
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("breakout.cr: open_orders_fail {error=%s}", exc)
+        open_orders = []
+
+    opposite_orders = [
+        o
+        for o in open_orders
+        if o.get("reduceOnly") and o.get("side") == exit_side
+    ]
+    sl_order = next((o for o in opposite_orders if o.get("type") == "STOP_MARKET"), None)
+    tp_order = next(
+        (o for o in opposite_orders if o.get("type") == "TAKE_PROFIT_MARKET"),
+        None,
+    )
+
+    eps = entry * 0.001
+
+    def _place(kind: str, price: float) -> None:
+        cid = sanitize_client_order_id(f"brk-{kind}-{uuid4().hex[:8]}")
+        if kind == "SL":
+            if hasattr(exchange, "place_stop_reduce_only"):
+                exchange.place_stop_reduce_only(symbol, exit_side, price, qty_abs, cid)
+            else:  # pragma: no cover - generic fallback
+                exchange._client.futures_create_order(  # type: ignore[attr-defined]
+                    symbol=symbol,
+                    side=exit_side,
+                    type="STOP_MARKET",
+                    stopPrice=price,
+                    quantity=qty_abs,
+                    reduceOnly=True,
+                    newClientOrderId=cid,
+                )
+        else:  # TP
+            if hasattr(exchange, "place_tp_reduce_only"):
+                exchange.place_tp_reduce_only(symbol, exit_side, price, qty_abs, cid)
+            else:  # pragma: no cover - generic fallback
+                exchange._client.futures_create_order(  # type: ignore[attr-defined]
+                    symbol=symbol,
+                    side=exit_side,
+                    type="TAKE_PROFIT_MARKET",
+                    stopPrice=price,
+                    quantity=qty_abs,
+                    reduceOnly=True,
+                    newClientOrderId=cid,
+                )
+        logger.info(
+            "breakout.cr: bracket_placed {type=%s, stop=%s, qty=%s}",
+            kind,
+            price,
+            qty_abs,
+        )
+
+    def _ensure(existing: dict | None, kind: str, price: float) -> None:
+        if existing:
+            try:
+                existing_price = float(existing.get("stopPrice") or existing.get("price") or 0)
+            except (TypeError, ValueError):
+                existing_price = 0.0
+            if abs(existing_price - price) <= eps:
+                logger.info("breakout.cr: bracket_skipped {reason=exists, type=%s}", kind)
+                return
+            try:
+                exchange.cancel_order(symbol, orderId=existing.get("orderId"))
+            except Exception:  # pragma: no cover - defensive
+                pass
+        _place(kind, price)
+
+    _ensure(sl_order, "SL", sl)
+    _ensure(tp_order, "TP", tp)
+
     return None

--- a/tests/test_breakout_cr_hook.py
+++ b/tests/test_breakout_cr_hook.py
@@ -1,0 +1,66 @@
+import logging
+from types import SimpleNamespace
+
+from strategies.breakout.cr_hook import run_cr_on_open_position
+
+
+class DummySettings:
+    def __init__(self, data):
+        self.data = data
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+
+class DummyBroker:
+    def __init__(self, open_orders=None):
+        self._open = list(open_orders or [])
+        self.placed = []
+        self.cancelled = []
+    def open_orders(self, symbol):
+        return list(self._open)
+    def place_stop_reduce_only(self, symbol, side, stopPrice, qty, clientOrderId):
+        self.placed.append(("SL", stopPrice, qty, side))
+    def place_tp_reduce_only(self, symbol, side, tpPrice, qty, clientOrderId):
+        self.placed.append(("TP", tpPrice, qty, side))
+    def cancel_order(self, symbol, orderId=None, clientOrderId=None):
+        self.cancelled.append(orderId or clientOrderId)
+    def get_symbol_filters(self, symbol):
+        return {"LOT_SIZE": {"minQty": "0.001"}}
+    def round_price_to_tick(self, symbol, px):
+        return px
+    def round_qty_to_step(self, symbol, qty):
+        return qty
+
+
+class DummyMD:
+    def get_price(self, symbol):
+        return 100.0
+
+
+def _ctx(broker, settings=None):
+    return {
+        "exchange": broker,
+        "settings": settings or DummySettings({"STOP_LOSS_PCT": 1, "TAKE_PROFIT_PCT": 1.5}),
+        "market_data": DummyMD(),
+    }
+
+
+def test_places_orders_when_missing():
+    brk = DummyBroker()
+    ctx = _ctx(brk)
+    position = {"positionAmt": "0.03", "entryPrice": "100"}
+    run_cr_on_open_position(ctx, "BTCUSDT", position)
+    assert ("SL", 99.0, 0.03, "SELL") in brk.placed
+    assert ("TP", 101.5, 0.03, "SELL") in brk.placed
+
+
+def test_skips_when_existing_within_epsilon():
+    existing = [
+        {"type": "STOP_MARKET", "side": "SELL", "stopPrice": "99", "reduceOnly": True, "orderId": 1},
+        {"type": "TAKE_PROFIT_MARKET", "side": "SELL", "stopPrice": "101.5", "reduceOnly": True, "orderId": 2},
+    ]
+    brk = DummyBroker(open_orders=existing)
+    ctx = _ctx(brk)
+    position = {"positionAmt": "0.03", "entryPrice": "100"}
+    run_cr_on_open_position(ctx, "BTCUSDT", position)
+    assert brk.placed == []


### PR DESCRIPTION
## Summary
- add breakout hook to place or update reduce-only stop-loss and take-profit orders from percentage settings
- include tests for breakout collateral hook behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic'; ModuleNotFoundError: No module named 'core.execution')*

------
https://chatgpt.com/codex/tasks/task_e_68c4f038df5c832d8e15713120ff8bf2