### PR TITLE
Refactor breakout debug logging

### DIFF
--- a/src/core/ports/settings.py
+++ b/src/core/ports/settings.py
@@ -27,6 +27,15 @@ def get_symbol_raw(settings: SettingsProvider) -> str:
     return str(settings.get("SYMBOL", "BTCUSDT"))
 
 
+def get_debug_mode(settings: SettingsProvider) -> bool:
+    """Return whether debug mode is enabled for the application."""
+
+    value = settings.get("DEBUG_MODE", False)
+    if value is None:
+        return False
+    return str(value).strip() in {"1", "true", "TRUE", "True"}
+
+
 def get_risk_pct(settings: SettingsProvider) -> float:
     return float(settings.get("RISK_PCT", 0.003))
 

--- a/src/strategies/breakout_dual_tf/core.py
+++ b/src/strategies/breakout_dual_tf/core.py
@@ -23,7 +23,7 @@ from config.settings import get_stop_loss_pct, get_take_profit_pct
 from core.domain.models.Signal import Signal
 from core.ports.broker import BrokerPort
 from core.ports.market_data import MarketDataPort
-from core.ports.settings import SettingsProvider, get_symbol
+from core.ports.settings import SettingsProvider, get_debug_mode, get_symbol
 from core.ports.strategy import Strategy
 
 logger = logging.getLogger("bot.strategy.breakout_dual_tf")
@@ -268,31 +268,30 @@ class BreakoutDualTFStrategy(Strategy):
         if exchange is None:
             return None
 
-        settings_obj = getattr(self, "_settings", None)
+        if not hasattr(self, "_logger"):
+            self._logger = logger
 
-        def _get_setting(key: str, default: Any | None = None) -> Any:
-            if settings_obj is None:
-                return default
-            getter = getattr(settings_obj, "get", None)
-            if callable(getter):
-                try:
-                    return getter(key, default)
-                except TypeError:  # pragma: no cover - defensive fallback
-                    return getter(key)
-            return getattr(settings_obj, key, default)
+        settings_obj: SettingsProvider | None = getattr(self, "_settings", None)
+        debug_mode = get_debug_mode(settings_obj) if settings_obj is not None else False
 
-        debug_raw = _get_setting("DEBUG_MODE")
-        logger.info("debug_raw: %s", debug_raw)
-        debug_mode = True #str(debug_raw) in {"1", "true", "TRUE", "True"}
-        log = getattr(self, "_logger", logger)
         if debug_mode:
-            log.debug(
+            testnet = (
+                settings_obj.get("BINANCE_TESTNET", None)
+                if settings_obj is not None
+                else None
+            )
+            trading_mode = (
+                settings_obj.get("TRADING_MODE", None)
+                if settings_obj is not None
+                else None
+            )
+            self._logger.debug(
                 "bdtf.poscheck.entry %s",
                 {
                     "symbol_in": symbol,
                     "side_in": side,
-                    "testnet": _get_setting("BINANCE_TESTNET"),
-                    "trading_mode": _get_setting("TRADING_MODE"),
+                    "testnet": testnet,
+                    "trading_mode": trading_mode,
                 },
             )
 
@@ -305,7 +304,7 @@ class BreakoutDualTFStrategy(Strategy):
                 broker_symbol = norm_symbol
 
         if debug_mode:
-            log.debug("bdtf.poscheck.symbol %s", {"symbol_norm": broker_symbol})
+            self._logger.debug("bdtf.poscheck.symbol %s", {"symbol_norm": broker_symbol})
 
         side_norm = str(side or "").strip().upper()
         side_norm = {"LONG": "BUY", "SHORT": "SELL"}.get(side_norm, side_norm)
@@ -389,7 +388,7 @@ class BreakoutDualTFStrategy(Strategy):
                         position_entry_price = entry_price
                         break
         except Exception as err:  # pragma: no cover - defensive
-            logger.warning(
+            self._logger.warning(
                 "positioncheck.error %s",
                 {
                     "strategy": "breakout_dual_tf",
@@ -400,7 +399,7 @@ class BreakoutDualTFStrategy(Strategy):
             )
 
         if debug_mode:
-            log.debug(
+            self._logger.debug(
                 "bdtf.poscheck.position %s",
                 {
                     "position_amt": position_amt,
@@ -421,9 +420,9 @@ class BreakoutDualTFStrategy(Strategy):
                 payload["positionSide"] = position_side_raw
             if side_norm != position_side:
                 payload["requested_side"] = side_norm
-            logger.info(json.dumps(payload))
+            self._logger.info(json.dumps(payload))
             if debug_mode:
-                log.debug(
+                self._logger.debug(
                     "bdtf.poscheck.summary %s",
                     {
                         "matched_entry_orders": matched_entry_orders,
@@ -462,7 +461,7 @@ class BreakoutDualTFStrategy(Strategy):
                 except TypeError:
                     open_orders = method(symbol=broker_symbol)
                 except Exception as err:  # pragma: no cover - defensive
-                    logger.warning(
+                    self._logger.warning(
                         "ordercheck.error %s",
                         {
                             "strategy": "breakout_dual_tf",
@@ -483,7 +482,7 @@ class BreakoutDualTFStrategy(Strategy):
             setattr(self, "_order_check_cache", cache)
         else:
             if debug_mode:
-                log.debug(
+                self._logger.debug(
                     "bdtf.poscheck.cache %s",
                     {"source": "reuse", "symbol": broker_symbol, "side": side_norm},
                 )
@@ -536,7 +535,7 @@ class BreakoutDualTFStrategy(Strategy):
                 or order.get("qty")
             )
             if debug_mode:
-                log.debug(
+                self._logger.debug(
                     "bdtf.poscheck.order %s",
                     {
                         "id": order_id,
@@ -550,7 +549,7 @@ class BreakoutDualTFStrategy(Strategy):
                 )
             if status not in active_statuses:
                 if debug_mode:
-                    log.debug(
+                    self._logger.debug(
                         "bdtf.poscheck.filter %s",
                         {"filter": "status_invalid", "orderId": order_id},
                     )
@@ -566,28 +565,28 @@ class BreakoutDualTFStrategy(Strategy):
             )
             if order_symbol_norm and order_symbol_norm != broker_symbol:
                 if debug_mode:
-                    log.debug(
+                    self._logger.debug(
                         "bdtf.poscheck.filter %s",
                         {"filter": "symbol_mismatch", "orderId": order_id},
                     )
                 continue
             if order_side != side_norm:
                 if debug_mode:
-                    log.debug(
+                    self._logger.debug(
                         "bdtf.poscheck.filter %s",
                         {"filter": "side_mismatch", "orderId": order_id},
                     )
                 continue
             if effective_reduce_only:
                 if debug_mode:
-                    log.debug(
+                    self._logger.debug(
                         "bdtf.poscheck.filter %s",
                         {"filter": "reduce_only", "orderId": order_id},
                     )
                 continue
             if client_id and not client_id.lower().startswith("bdtf-"):
                 if debug_mode:
-                    log.debug(
+                    self._logger.debug(
                         "bdtf.poscheck.filter %s",
                         {"filter": "prefix_mismatch", "orderId": order_id},
                     )
@@ -616,9 +615,9 @@ class BreakoutDualTFStrategy(Strategy):
                 )
                 for order in working_orders
             ]
-            logger.info(json.dumps(payload))
+            self._logger.info(json.dumps(payload))
             if debug_mode:
-                log.debug(
+                self._logger.debug(
                     "bdtf.poscheck.summary %s",
                     {
                         "matched_entry_orders": matched_entry_orders,
@@ -629,7 +628,7 @@ class BreakoutDualTFStrategy(Strategy):
             return payload
 
         if debug_mode:
-            log.debug(
+            self._logger.debug(
                 "bdtf.poscheck.summary %s",
                 {
                     "matched_entry_orders": matched_entry_orders,

--- a/tests/test_settings_debug_mode.py
+++ b/tests/test_settings_debug_mode.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
+
+from core.ports.settings import get_debug_mode
+
+
+class DummySettings:
+    def __init__(self, values=None):
+        self._values = values or {}
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+def test_get_debug_mode_accepts_truthy_strings():
+    for value in ["1", "true", "TRUE", "True"]:
+        settings = DummySettings({"DEBUG_MODE": value})
+        assert get_debug_mode(settings) is True
+
+
+def test_get_debug_mode_falsey_values_and_default():
+    falsey_cases = ["0", "false", None]
+    for value in falsey_cases:
+        values = {"DEBUG_MODE": value} if value is not None else {}
+        settings = DummySettings(values)
+        assert get_debug_mode(settings) is False


### PR DESCRIPTION
## Summary
- add a `get_debug_mode` helper to `SettingsProvider` utilities
- consume the debug flag and strategy logger directly inside `_has_active_position_or_orders`
- cover the new helper with unit tests for the expected string conversions

## Testing
- pytest tests/test_settings_debug_mode.py
- pytest tests/test_breakout_dual_tf.py::test_has_active_orders_normalizes_symbol_and_side_mapping
- pytest tests/test_breakout_dual_tf.py::test_has_active_orders_filters_non_strategy_entries

------
https://chatgpt.com/codex/tasks/task_e_68d061c72e98832d8b0f689629abf093