### PR TITLE
Fix candidate rounding helper

### DIFF
--- a/src/strategies/liquidity_sweep/strategy.py
+++ b/src/strategies/liquidity_sweep/strategy.py
@@ -227,14 +227,6 @@ def compute_levels(candles_m1: Sequence[Sequence[float]], *args: Any, **kwargs: 
         ]
     return result
 
-def _round_to_tick(value: float, tick: float) -> float:
-    """Round ``value`` to the closest ``tick`` size."""
-
-    if tick:
-        return round(value / tick) * tick
-    return value
-
-
 def build_entry_prices(levels: Mapping[str, float], *args: Any, **kwargs: Any) -> Mapping[str, float]:
     """Derive entry prices from previously computed ``levels``.
 

--- a/src/strategies/liquidity_sweep/strategy.py
+++ b/src/strategies/liquidity_sweep/strategy.py
@@ -94,6 +94,11 @@ def compute_levels(candles_m1: Sequence[Sequence[float]], *args: Any, **kwargs: 
             return round(value / tick) * tick
         return value
 
+    def _round_to_tick_with(value: float, tick: float) -> float:
+        if tick:
+            return round(value / tick) * tick
+        return value
+
     # ------------------------------------------------------------------
     # ATR calculations
     atr1m = _atr(candles_m1)
@@ -208,15 +213,16 @@ def compute_levels(candles_m1: Sequence[Sequence[float]], *args: Any, **kwargs: 
         "microbuffer": microbuffer,
         "buffer_sl": buffer_sl,
     }
+    tick_size = float(getattr(settings, "TICK_SIZE", 0.0)) if settings else 0.0
     if include_candidates:
         result["supports_candidates"] = supports_sorted or [S]
         result["resistances_candidates"] = resistances_sorted or [R]
         result["supports_candidates"] = [
-            _round_to_tick(val, tick=float(getattr(settings, "TICK_SIZE", 0.0)) if settings else 0.0)
+            _round_to_tick_with(val, tick_size)
             for val in result["supports_candidates"]
         ]
         result["resistances_candidates"] = [
-            _round_to_tick(val, tick=float(getattr(settings, "TICK_SIZE", 0.0)) if settings else 0.0)
+            _round_to_tick_with(val, tick_size)
             for val in result["resistances_candidates"]
         ]
     return result


### PR DESCRIPTION
## Summary
- add a helper that rounds values with a provided tick size inside compute_levels
- reuse a local tick size when rounding candidate levels to avoid keyword arguments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb62331ac832d867d9db974406374