### PR TITLE
Persist breakout TP values in S3

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for the trading bot."""
+
+__all__ = []

--- a/src/utils/tp_store_s3.py
+++ b/src/utils/tp_store_s3.py
@@ -1,0 +1,128 @@
+"""Helpers to persist and retrieve take-profit values from S3."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+
+logger = logging.getLogger("bot.tp_store_s3")
+
+_S3_BUCKET = "trading-bot-storage-aa"
+_S3_PREFIX = "tp"
+
+
+def _build_key(symbol: str) -> str:
+    symbol_clean = str(symbol or "").strip()
+    if not symbol_clean:
+        raise ValueError("Symbol required to build S3 key")
+    return f"{_S3_PREFIX}/{symbol_clean}.json"
+
+
+def persist_tp_value(symbol: str, tp_value: float, timestamp: int | float) -> bool:
+    """Persist the take-profit value for ``symbol`` in S3."""
+
+    key = _build_key(symbol)
+    payload = {
+        "symbol": str(symbol),
+        "tp_value": float(tp_value),
+        "timestamp": timestamp,
+    }
+
+    body = json.dumps(payload).encode("utf-8")
+    client = boto3.client("s3")
+    try:
+        client.put_object(
+            Bucket=_S3_BUCKET,
+            Key=key,
+            Body=body,
+            ContentType="application/json",
+        )
+    except (ClientError, BotoCoreError) as exc:
+        logger.warning(
+            "tp_s3_persist.error %s",
+            {"bucket": _S3_BUCKET, "key": key, "error": str(exc)},
+        )
+        return False
+
+    logger.info(
+        "tp_s3_persist.success %s",
+        {"bucket": _S3_BUCKET, "key": key, "tp_value": payload["tp_value"]},
+    )
+    return True
+
+
+def load_tp_value(symbol: str) -> float | None:
+    """Load a previously persisted take-profit value for ``symbol`` from S3."""
+
+    key = _build_key(symbol)
+    client = boto3.client("s3")
+    try:
+        response = client.get_object(Bucket=_S3_BUCKET, Key=key)
+    except ClientError as exc:
+        error_code = exc.response.get("Error", {}).get("Code", "") if hasattr(exc, "response") else ""
+        if error_code in {"NoSuchKey", "404"}:
+            logger.info(
+                "tp_s3_load.missing %s",
+                {"bucket": _S3_BUCKET, "key": key, "reason": "no_object"},
+            )
+            return None
+        logger.warning(
+            "tp_s3_load.error %s",
+            {"bucket": _S3_BUCKET, "key": key, "error": str(exc)},
+        )
+        return None
+    except BotoCoreError as exc:
+        logger.warning(
+            "tp_s3_load.error %s",
+            {"bucket": _S3_BUCKET, "key": key, "error": str(exc)},
+        )
+        return None
+
+    body = response.get("Body")
+    if body is None:
+        logger.info(
+            "tp_s3_load.missing %s",
+            {"bucket": _S3_BUCKET, "key": key, "reason": "empty_body"},
+        )
+        return None
+
+    try:
+        raw = body.read()
+        data: Any = json.loads(raw.decode("utf-8"))
+    except (ValueError, AttributeError) as exc:
+        logger.warning(
+            "tp_s3_load.error %s",
+            {"bucket": _S3_BUCKET, "key": key, "error": str(exc)},
+        )
+        return None
+
+    value = data.get("tp_value") if isinstance(data, dict) else None
+    if value is None:
+        logger.info(
+            "tp_s3_load.missing %s",
+            {"bucket": _S3_BUCKET, "key": key, "reason": "no_value"},
+        )
+        return None
+
+    try:
+        tp_value = float(value)
+    except (TypeError, ValueError):
+        logger.info(
+            "tp_s3_load.missing %s",
+            {"bucket": _S3_BUCKET, "key": key, "reason": "invalid_value", "value": value},
+        )
+        return None
+
+    logger.info(
+        "tp_s3_load.success %s",
+        {"bucket": _S3_BUCKET, "key": key, "tp_value": tp_value},
+    )
+    return tp_value
+
+
+__all__ = ["persist_tp_value", "load_tp_value"]


### PR DESCRIPTION
## Summary
- add an S3-backed helper to store and retrieve take-profit values
- persist the ATR-based take-profit price when breakout dual TF orders are created
- restore missing take-profit close-all orders using the value loaded from S3

## Testing
- pytest tests/test_breakout_cr_hook.py *(fails: ModuleNotFoundError: No module named 'strategies')*

------
https://chatgpt.com/codex/tasks/task_e_68dff895fb94832d9af80c71818db6c4